### PR TITLE
feat(services): allow local config to be used instead of redirecting to a URL

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -11,6 +11,7 @@
     "generateTimeout": 30000
   },
   "ENDPOINT_SERVICE_URL": "http://central-ledger.local:3001",
+  "PARTICIPANT_LIST_SERVICE_URL": "http://ml-testing-toolkit:5000",
   "PARTICIPANT_LIST_LOCAL": [
     "dfspa",
     "dfspb"

--- a/config/default.json
+++ b/config/default.json
@@ -11,7 +11,10 @@
     "generateTimeout": 30000
   },
   "ENDPOINT_SERVICE_URL": "http://central-ledger.local:3001",
-  "PARTICIPANT_LIST_SERVICE_URL": "http://ml-testing-toolkit:5000",
+  "PARTICIPANT_LIST_LOCAL": [
+    "dfspa",
+    "dfspb"
+  ],
   "ERROR_HANDLING": {
     "includeCauseExtension": true,
     "truncateExtensions": true

--- a/src/server/handlers/services/{ServiceType}.ts
+++ b/src/server/handlers/services/{ServiceType}.ts
@@ -47,7 +47,7 @@ import { getSpanTags } from '~/shared/util'
   * produces: application/json
   * responses: 202, 400, 401, 403, 404, 405, 406, 501, 503
   */
-const get = async (_context: unknown, request: Request, h: ResponseToolkit): Promise<ResponseObject> => {
+const get = async (_context: unknown, request: Request, h: ResponseToolkit): Promise<ResponseObject> => {  
   const span = (request as any).span
   const serviceType: string = request.params.ServiceType
   try {

--- a/src/server/handlers/services/{ServiceType}.ts
+++ b/src/server/handlers/services/{ServiceType}.ts
@@ -65,19 +65,20 @@ const get = async (_context: unknown, request: Request, h: ResponseToolkit): Pro
 
     // If PARTICIPANT_LIST_LOCAL is set, then we should use the local config to
     // respond to this request instead of forwarding it to another service
+    // This is guaranteed to be mutually exclusive by Config
     if (Config.PARTICIPANT_LIST_LOCAL) {
       const payload: tpAPI.Schemas.ServicesServiceTypePutResponse = {
         providers: Config.PARTICIPANT_LIST_LOCAL
       }
 
-      // reverse the Source and Destination headers
-      const sourceDfspId = request.headers[Enum.Http.Headers.FSPIOP.SOURCE]
-      const destinationDfspId = request.headers[Enum.Http.Headers.FSPIOP.DESTINATION]
+      // this is a reply: Source header must become Destination
+      // destination header should be Switch
+      const destinationDfspId = request.headers[Enum.Http.Headers.FSPIOP.SOURCE]
       const headers = {
         ...request.headers,
       }
-      headers[Enum.Http.Headers.FSPIOP.DESTINATION] = sourceDfspId
-      headers[Enum.Http.Headers.FSPIOP.SOURCE] = destinationDfspId
+      headers[Enum.Http.Headers.FSPIOP.SOURCE] = Enum.Http.Headers.FSPIOP.SWITCH.value
+      headers[Enum.Http.Headers.FSPIOP.DESTINATION] = destinationDfspId
 
       // Note: calling async function without `await`
       forwardGetServicesServiceTypeRequestFromProviderService(

--- a/test/unit/server/handlers/services/ServiceTypeLocal.test.ts
+++ b/test/unit/server/handlers/services/ServiceTypeLocal.test.ts
@@ -1,0 +1,69 @@
+/*****
+ License
+--------------
+Copyright © 2020 Mojaloop Foundation
+The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the 'License') and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+Contributors
+--------------
+This is the official list of the Mojaloop project contributors for this file.
+Names of the original copyright holders (individuals or organizations)
+should be listed with a '*' in the first column. People who have
+contributed from an organization can be listed under the organization
+that actually holds the copyright for their contributions (see the
+Gates Foundation organization for an example). Those individuals should have
+their names indented and be marked with a '-'. Email address can be added
+optionally within square brackets <email>.
+* Gates Foundation
+- Name Surname <name.surname@gatesfoundation.com>
+
+- Lewis Daly <lewisd@crosslaketech.com>
+
+--------------
+******/
+import { Request } from '@hapi/hapi'
+import '~/shared/config'
+
+jest.mock('~/shared/config', () => ({
+  PARTICIPANT_LIST_SERVICE_URL: undefined,
+  PARTICIPANT_LIST_LOCAL: ['dfspa', 'dfspb']
+}));
+
+import * as Services from '~/domain/services'
+import { mockResponseToolkit } from 'test/unit/__mocks__/responseToolkit'
+import ServicesServiceTypeHandler from '~/server/handlers/services/{ServiceType}'
+import TestData from 'test/unit/data/mockData.json'
+const mockData = JSON.parse(JSON.stringify(TestData))
+
+const forwardGetServicesServiceTypeRequestFromProviderService = jest.spyOn(Services, 'forwardGetServicesServiceTypeRequestFromProviderService')
+const getServicesByServiceTypeRequest = mockData.getServicesByServiceTypeRequest
+const putServicesByServiceTypeRequest = mockData.putServicesByServiceTypeRequest
+
+
+describe.only('GET /services/{{ServiceType}} with PARTICIPANT_LIST_LOCAL', () => {
+  it('handles a successful request', async () => {
+    // Arrange
+    forwardGetServicesServiceTypeRequestFromProviderService.mockResolvedValueOnce()
+    const expected = [
+      '/services/{{ServiceType}}',
+      'TP_CB_URL_SERVICES_PUT',
+      putServicesByServiceTypeRequest.headers,
+      'PUT',
+      getServicesByServiceTypeRequest.params.ServiceType,
+      putServicesByServiceTypeRequest.payload,
+      undefined
+    ]
+
+    // Act
+    const response = await ServicesServiceTypeHandler.get(
+      null,
+      getServicesByServiceTypeRequest as unknown as Request,
+      mockResponseToolkit
+    )
+
+    // Assert
+    expect(response.statusCode).toBe(202)
+    expect(forwardGetServicesServiceTypeRequestFromProviderService).toHaveBeenCalledWith(...expected)
+  })
+})

--- a/test/unit/server/handlers/services/{ServiceType}.test.ts
+++ b/test/unit/server/handlers/services/{ServiceType}.test.ts
@@ -26,6 +26,11 @@ import { Request } from '@hapi/hapi'
 import Logger from '@mojaloop/central-services-logger'
 import Config from '~/shared/config'
 
+jest.mock('~/shared/config', () => ({
+  PARTICIPANT_LIST_SERVICE_URL: 'http://ml-testing-toolkit:5000',
+  PARTICIPANT_LIST_LOCAL: undefined
+}));
+
 
 import * as Services from '~/domain/services'
 import { mockResponseToolkit } from 'test/unit/__mocks__/responseToolkit'
@@ -114,42 +119,6 @@ describe('ServicesServiceType handler', () => {
     })
   })
 
-  describe('GET /services/{{ServiceType}} with PARTICIPANT_LIST_LOCAL', () => {
-    jest.mock('~/shared/config', () => ({
-      __esModule: true, // this property makes it work
-      default: 'mockedDefaultExport',
-      namedExport: jest.fn(),
-    }));
-
-    // Custom Config override
-    Config.PARTICIPANT_LIST_SERVICE_URL = undefined
-    Config.PARTICIPANT_LIST_LOCAL = [ 'dfspa', 'dfspb' ]
-
-    it('handles a successful request', async () => {
-      // Arrange
-      forwardGetServicesServiceTypeRequestFromProviderService.mockResolvedValueOnce()
-      const expected = [
-        '/services/{{ServiceType}}',
-        'TP_CB_URL_SERVICES_PUT',
-        putServicesByServiceTypeRequest.headers,
-        'PUT',
-        getServicesByServiceTypeRequest.params.ServiceType,
-        putServicesByServiceTypeRequest.payload,
-        undefined
-      ]
-
-      // Act
-      const response = await ServicesServiceTypeHandler.get(
-        null,
-        getServicesByServiceTypeRequest as unknown as Request,
-        mockResponseToolkit
-      )
-
-      // Assert
-      expect(response.statusCode).toBe(202)
-      expect(forwardGetServicesServiceTypeRequestFromProviderService).toHaveBeenCalledWith(...expected)
-    })
-  })
 
   describe('PUT /services/{{ServiceType}}', () => {
     beforeEach((): void => {

--- a/test/unit/server/handlers/services/{ServiceType}.test.ts
+++ b/test/unit/server/handlers/services/{ServiceType}.test.ts
@@ -125,7 +125,7 @@ describe('ServicesServiceType handler', () => {
     Config.PARTICIPANT_LIST_SERVICE_URL = undefined
     Config.PARTICIPANT_LIST_LOCAL = [ 'dfspa', 'dfspb' ]
 
-    it.only('handles a successful request', async () => {
+    it('handles a successful request', async () => {
       // Arrange
       forwardGetServicesServiceTypeRequestFromProviderService.mockResolvedValueOnce()
       const expected = [

--- a/test/unit/shared/logger.test.ts
+++ b/test/unit/shared/logger.test.ts
@@ -27,7 +27,9 @@ import inspect from '~/shared/inspect'
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 jest.mock('@mojaloop/central-services-logger', () => ({
-  info: jest.fn()
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
 }))
 
 describe('shared/logger', (): void => {


### PR DESCRIPTION
We're having trouble getting the thirdparty charts integrated into the mojaloop/helm charts because of the added complexity and flakiness of using a TTK to mock out the `/services` resource.

This PR adds the ability to specify `PARTICIPANT_LIST_LOCAL`, a list of participantIds that will be used in a `PUT /services` callback instead of forwarding the `GET /services` request to another service.

It's fully backwards compatible, so if you don't set `PARTICIPANT_LIST_LOCAL`, the existing behaviour (forwarding that request to some other API) will be used.